### PR TITLE
Fix repository link

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ description = "First class Zig support for the Zed editor."
 version = "0.1.0"
 schema_version = 1
 authors = ["viable <hi@viable.gg>"]
-repository = "https://github.com/nuiipointerexception/zed-zig"
+repository = "https://github.com/nuiipointerexception/zed_zig"
 snippets = "./snippets/zig.json"
 
 [language_servers.zls]


### PR DESCRIPTION
Opening repo from zed editor leads to nonexisting repo since repo name has _ instead of -
